### PR TITLE
Update XMTP SDK version and set app version in config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages": "tsx scripts/packages.ts"
   },
   "dependencies": {
-    "@xmtp/node-sdk": "4.1.0-rc1",
+    "@xmtp/node-sdk": "4.1.0",
     "piscina": "^5.1.3",
     "uint8arrays": "^5.1.0",
     "viem": "^2.22.17"

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ async function main() {
     dbEncryptionKey,
     env,
     loggingLevel: LOGGING_LEVEL as LogLevel,
+    appVersion:'gm-bot/1.0.0',
     dbPath: getDbPath("gm-bot-"+env),
   });
   let messageCount = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,20 +379,20 @@
   dependencies:
     "@xmtp/content-type-primitives" "^2.0.2"
 
-"@xmtp/node-bindings@1.4.0-rc1":
-  version "1.4.0-rc1"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.4.0-rc1.tgz#978c7b062b4815132d8f8f7258deb52cff7ec4dc"
-  integrity sha512-JY4odudXPXn7g+w8DFssgce1DLAWZspFy47E201w75dmKgwTBOAIzHTbK9FtQvuxVZO0vG+y79/MrJvN1RBwsA==
+"@xmtp/node-bindings@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.4.0.tgz#aee7da306cf5edf2dbd5bbb81b5a9d1f121e2e75"
+  integrity sha512-NfpbDc0gdhDY+5x1gxlv3I/5EtGLuwfkQszy08HXQHCchFrdpyA3NcnM9C2OQK7992H7f+bGEUlzaRze6Iqrbw==
 
-"@xmtp/node-sdk@4.1.0-rc1":
-  version "4.1.0-rc1"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.1.0-rc1.tgz#782c28e1aed72ad16693174865fb274adc09000e"
-  integrity sha512-JkVomsZE5OVPcQmiltJ1n85Jw64qE1rhhllgnKdQgQwxHl5LJsCiSRIc8K8L9utmuHiW9nNPT5vtpAanM3Ndig==
+"@xmtp/node-sdk@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.1.0.tgz#5a4c987255e973d448820dcba3c99b590ef49485"
+  integrity sha512-tDXrwVnxUzyrjlmFE9FuBpR2j8OtE4hrDMLdBpEvoTjMHvWiPyzaxHoE8FZLOaSoW/zwncGHLH0VE59j7PQx+g==
   dependencies:
     "@xmtp/content-type-group-updated" "^2.0.2"
     "@xmtp/content-type-primitives" "^2.0.2"
     "@xmtp/content-type-text" "^2.0.2"
-    "@xmtp/node-bindings" "1.4.0-rc1"
+    "@xmtp/node-bindings" "1.4.0"
 
 "@xmtp/proto@^3.78.0":
   version "3.86.0"


### PR DESCRIPTION
### Install '@xmtp/node-sdk' 4.1.0 and set `Client.create` option `appVersion` to 'gm-bot/1.0.0' in [src/index.ts](https://github.com/xmtp/gm-bot/pull/56/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to update the XMTP SDK version and set the app version in config
- Modify dependency declarations in [package.json](https://github.com/xmtp/gm-bot/pull/56/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
- Add a configuration option in the client initialization in [src/index.ts](https://github.com/xmtp/gm-bot/pull/56/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
- Refresh generated dependency resolutions in [yarn.lock](https://github.com/xmtp/gm-bot/pull/56/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the `Client.create` invocation in [src/index.ts](https://github.com/xmtp/gm-bot/pull/56/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 4ce102a._