### PR TITLE
Update .env load condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@
 import { Agent, getTestUrl, type LogLevel  } from "@xmtp/agent-sdk";
 import fs from "fs";
 
-process.loadEnvFile(".env");
+// Load .env file only in local development
+if (process.env.NODE_ENV !== 'production') {
+  process.loadEnvFile(".env");
+}
 
   // 2. Spin up the agent
 const agent = await Agent.createFromEnv({


### PR DESCRIPTION
### Gate `.env` loading in `src/index.ts` to run `process.loadEnvFile('.env')` only when `process.env.NODE_ENV !== 'production'` to update the .env load condition
Wrap the call to `process.loadEnvFile('.env')` in a conditional check against `process.env.NODE_ENV` in [index.ts](https://github.com/xmtp/gm-bot/pull/59/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80). An inline comment explains the condition.

#### 📍Where to Start
Begin at the app entry point where environment initialization occurs in [index.ts](https://github.com/xmtp/gm-bot/pull/59/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), focusing on the conditional around `process.loadEnvFile('.env')`.

----

_[Macroscope](https://app.macroscope.com) summarized ec099c7._