### PR TITLE
Refactor agent event handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const agent = await Agent.createFromEnv({
   dbPath: getDbPath("gm-bot-"+process.env.XMTP_ENV),
 });
 
-agent.on("text", async (ctx : any) => {
+agent.on("text", async (ctx) => {
   await ctx.conversation.send("gm: " + ctx.message.content);
 });
 


### PR DESCRIPTION
### Remove explicit `any` type from `agent.on('text')` handler parameter in [src/index.ts](https://github.com/xmtp/gm-bot/pull/61/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to refactor agent event handler
The `ctx` parameter in the `agent.on('text', async (ctx) => ...)` handler in [src/index.ts](https://github.com/xmtp/gm-bot/pull/61/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) removes the explicit `: any` annotation, relying on TypeScript type inference.

#### 📍Where to Start
Start with the `agent.on('text', async (ctx) => ...)` handler in [src/index.ts](https://github.com/xmtp/gm-bot/pull/61/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 3d1a7ec._