### PR TITLE
Add unhandled error handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const agent = await Agent.createFromEnv({
   dbPath: getDbPath("gm-bot-"+process.env.XMTP_ENV),
 });
 
-agent.on("text", async (ctx : any) => {
+agent.on("text", async (ctx) => {
   await ctx.conversation.send("gm: " + ctx.message.content);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ const agent = await Agent.createFromEnv({
   dbPath: getDbPath("gm-bot-"+process.env.XMTP_ENV),
 });
 
+// Handle uncaught errors
+agent.on("unhandledError", (error) => {
+  console.error("Agent error", error);
+});
+
 agent.on("text", async (ctx) => {
   await ctx.conversation.send("gm: " + ctx.message.content);
 });


### PR DESCRIPTION
### Log agent 'unhandledError' events to stderr in [index.ts](https://github.com/xmtp/gm-bot/pull/62/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to add an unhandled error handler
Add a listener on the agent for the `unhandledError` event in [index.ts](https://github.com/xmtp/gm-bot/pull/62/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) that writes the error to stderr via `console.error` with the prefix `Agent error`, and include an inline comment documenting this behavior.

#### 📍Where to Start
Start with the agent `unhandledError` event listener in [index.ts](https://github.com/xmtp/gm-bot/pull/62/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized ddfe421._