### PR TITLE
Update agent-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gen:keys": "tsx scripts/generateKeys.ts"
   },
   "dependencies": {
-    "@xmtp/agent-sdk": "^0.0.9"
+    "@xmtp/agent-sdk": "^0.0.11"
   },
   "devDependencies": {
     "tsx": "^4.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,10 +253,10 @@
   dependencies:
     undici-types "~7.8.0"
 
-"@xmtp/agent-sdk@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.9.tgz#5b5e4b36d3b176e1d2e7c2bed801e2040c0c3733"
-  integrity sha512-GXJuPjqsCWFr7HNc+1ZAyda0Y/4aWOD3Kt8RDpaHwRjyhWLBr0EvOMW0mEFIEy2GPLiwVZIxGpLzrT8XgxFaTg==
+"@xmtp/agent-sdk@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.11.tgz#8983e675689fd353cb8c33fad8a56b30a2110c7e"
+  integrity sha512-RqZAycAtifWfRGe2R0F9FnWfKgavwgEQciN0vpeCP8mbmnkzsXfqWcpKJnt8jqrN0Lx/AZf8KRnFNkKtFJ7eEw==
   dependencies:
     "@xmtp/content-type-reaction" "^2.0.2"
     "@xmtp/content-type-remote-attachment" "^2.0.2"


### PR DESCRIPTION
### Bump `@xmtp/agent-sdk` dependency to `^0.0.11` in `package.json` to update agent SDK version
This change updates the project to use `@xmtp/agent-sdk` version `^0.0.11` and refreshes the lockfile to match.

- Update `@xmtp/agent-sdk` version spec from `^0.0.9` to `^0.0.11` in [package.json](https://github.com/xmtp/gm-bot/pull/63/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
- Regenerate dependency resolutions in [yarn.lock](https://github.com/xmtp/gm-bot/pull/63/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect the new version and transitive updates

#### 📍Where to Start
Start with the dependency version bump in [package.json](https://github.com/xmtp/gm-bot/pull/63/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), then verify resolved versions in [yarn.lock](https://github.com/xmtp/gm-bot/pull/63/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

----

_[Macroscope](https://app.macroscope.com) summarized b9238c4._