### PR TITLE
Update agent-sdk usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gen:keys": "tsx scripts/generateKeys.ts"
   },
   "dependencies": {
-    "@xmtp/agent-sdk": "^0.0.11"
+    "@xmtp/agent-sdk": "latest"
   },
   "devDependencies": {
     "tsx": "^4.19.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 
-import { Agent, getTestUrl, type LogLevel  } from "@xmtp/agent-sdk";
+import { Agent, createSigner, createUser, getTestUrl, LogLevel,   } from "@xmtp/agent-sdk";
 import fs from "fs";
 
 // Load .env file only in local development
@@ -7,23 +7,20 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
 
   // 2. Spin up the agent
-const agent = await Agent.createFromEnv({
+const agent = await Agent.create(createSigner(createUser(process.env.XMTP_WALLET_KEY as `0x${string}`)), {
   appVersion:'gm-bot/1.0.0',
-  loggingLevel: "warn" as LogLevel,
+    loggingLevel: "warn" as LogLevel,
+  env: process.env.XMTP_DB_ENCRYPTION_KEY as "local" | "dev" | "production",
   dbPath: getDbPath("gm-bot-"+process.env.XMTP_ENV),
 });
 
-// Handle uncaught errors
-agent.on("unhandledError", (error) => {
-  console.error("Agent error", error);
-});
-
-agent.on("text", async (ctx) => {
+agent.on("text",  async (ctx: any) => {
+  console.log(ctx.message);
   await ctx.conversation.send("gm: " + ctx.message.content);
 });
 
 // 4. Log when we're ready
-agent.on("start", () => {
+agent.on("start", (): void => {
   console.log(`Waiting for messages...`);
   console.log(`Address: ${agent.client.accountIdentifier?.identifier}`);
   console.log(`🔗${getTestUrl(agent)}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,10 +253,10 @@
   dependencies:
     undici-types "~7.8.0"
 
-"@xmtp/agent-sdk@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.11.tgz#8983e675689fd353cb8c33fad8a56b30a2110c7e"
-  integrity sha512-RqZAycAtifWfRGe2R0F9FnWfKgavwgEQciN0vpeCP8mbmnkzsXfqWcpKJnt8jqrN0Lx/AZf8KRnFNkKtFJ7eEw==
+"@xmtp/agent-sdk@latest":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.12.tgz#da4dfd9fe93d926892e69eb09d9421bf28789bab"
+  integrity sha512-MgQeil6+21vMVGvFPksyoTXxf37EcoFOX/2rbquraQ7MDFqf+YKfODQVykuuOYQngKI9iUk0S/D299gTCvKrbA==
   dependencies:
     "@xmtp/content-type-reaction" "^2.0.2"
     "@xmtp/content-type-remote-attachment" "^2.0.2"


### PR DESCRIPTION
### Update agent initialization to use `@xmtp/agent-sdk` latest with `Agent.create(createSigner(createUser(process.env.XMTP_WALLET_KEY as `0x${string}`)), ...)` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/64/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to align with the update agent-sdk usage purpose
- Update dependency constraint for `@xmtp/agent-sdk` to `latest` in [package.json](https://github.com/xmtp/gm-bot/pull/64/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
- Replace `Agent.createFromEnv` with `Agent.create(createSigner(createUser(process.env.XMTP_WALLET_KEY as `0x${string}`)), {...})` and set `env` from `process.env.XMTP_DB_ENCRYPTION_KEY` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/64/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
- Switch `LogLevel` to a value import and pass `"warn"` for `loggingLevel` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/64/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
- Add console logging of `ctx.message` in the `text` event handler and explicitly type `ctx` as `any` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/64/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
- Remove the `unhandledError` event listener and annotate the `start` handler with an explicit `void` return type in [src/index.ts](https://github.com/xmtp/gm-bot/pull/64/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).
- Update lockfile entries in [yarn.lock](https://github.com/xmtp/gm-bot/pull/64/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the agent construction and configuration in [src/index.ts](https://github.com/xmtp/gm-bot/pull/64/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), focusing on the switch from `Agent.createFromEnv` to `Agent.create(createSigner(createUser(...)), {...})`.

----

_[Macroscope](https://app.macroscope.com) summarized e22ac75._