### PR TITLE
"Refactor dbPath assignment"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 
-import { Agent, createSigner, createUser, getTestUrl, LogLevel,   } from "@xmtp/agent-sdk";
+import { Agent, getTestUrl, LogLevel,   } from "@xmtp/agent-sdk";
 
 // Load .env file only in local development
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
 
   // 2. Spin up the agent
-const agent = await Agent.create(createSigner(createUser(process.env.XMTP_WALLET_KEY as `0x${string}`)), {
+const agent = await Agent.createFromEnv({
   appVersion:'gm-bot/1.0.0',
-    loggingLevel: "warn" as LogLevel,
-  env: process.env.XMTP_DB_ENCRYPTION_KEY as "local" | "dev" | "production",
-  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp"
+  env: process.env.XMTP_ENV as "local" | "dev" | "production",
+  loggingLevel: "warn" as LogLevel,
+  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot-` + process.env.XMTP_ENV
 });
 
 agent.on("text",  async (ctx: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 
 import { Agent, createSigner, createUser, getTestUrl, LogLevel,   } from "@xmtp/agent-sdk";
-import fs from "fs";
 
 // Load .env file only in local development
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
@@ -11,7 +10,7 @@ const agent = await Agent.create(createSigner(createUser(process.env.XMTP_WALLET
   appVersion:'gm-bot/1.0.0',
     loggingLevel: "warn" as LogLevel,
   env: process.env.XMTP_DB_ENCRYPTION_KEY as "local" | "dev" | "production",
-  dbPath: getDbPath("gm-bot-"+process.env.XMTP_ENV),
+  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp"
 });
 
 agent.on("text",  async (ctx: any) => {
@@ -27,14 +26,3 @@ agent.on("start", (): void => {
 });
 
 await agent.start();
-
-
-function getDbPath(description: string = "xmtp") {
-  //Checks if the environment is a Railway deployment
-  const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
-  // Create database directory if it doesn't exist
-  if (!fs.existsSync(volumePath)) {
-    fs.mkdirSync(volumePath, { recursive: true });
-  }
-  return `${volumePath}/${process.env.XMTP_ENV}-${description}.db3`;
-}


### PR DESCRIPTION
### Refactor dbPath assignment by updating `src/index` to initialize `Agent` with `Agent.createFromEnv` and construct the database path from `process.env.RAILWAY_VOLUME_MOUNT_PATH` or `.data/xmtp/` plus `${process.env.XMTP_ENV}-gm-bot-${process.env.XMTP_ENV}`
This change updates `src/index` to use `Agent.createFromEnv` for initialization and constructs the database path inline based on environment variables. It removes the `getDbPath` helper and related imports and adjusts environment sourcing for the XMTP environment.

- Replace `Agent.create(createSigner(createUser(process.env.XMTP_WALLET_KEY)), {...})` with `Agent.createFromEnv({...})` in [index.ts](https://github.com/xmtp/gm-bot/pull/65/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Source `env` from `process.env.XMTP_ENV` and build `dbPath` using `process.env.RAILWAY_VOLUME_MOUNT_PATH` fallback to `.data/xmtp/` plus `${process.env.XMTP_ENV}-gm-bot-${process.env.XMTP_ENV}` in [index.ts](https://github.com/xmtp/gm-bot/pull/65/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Remove imports for `createSigner`, `createUser`, and `fs`, and delete the `getDbPath` utility along with its `.db3` filename convention and directory-creation behavior

#### 📍Where to Start
Start with `Agent` initialization in [index.ts](https://github.com/xmtp/gm-bot/pull/65/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), focusing on the `Agent.createFromEnv` call and the inline `dbPath` construction.

----

_[Macroscope](https://app.macroscope.com) summarized 1534240._