### PR TITLE
Add exit and dbPath extension

### DIFF
--- a/scripts/revokeInstallations.ts
+++ b/scripts/revokeInstallations.ts
@@ -246,6 +246,7 @@ async function main() {
     console.log(
       `✓ Final installations: ${finalInboxState[0].installations.length}`,
     );
+    process.exit(0);
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error("Error revoking installations:", errorMessage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 
 import { Agent, getTestUrl, LogLevel, XmtpEnv  } from "@xmtp/agent-sdk";
+import fs from "fs";
 
 // Load .env file only in local development
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
@@ -10,7 +11,7 @@ const agent = await Agent.createFromEnv({
   appVersion:'gm-bot/1.0.0',
   env: process.env.XMTP_ENV as XmtpEnv  ,
   loggingLevel: "warn" as LogLevel,
-  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot.db3`
+  dbPath: getDbPath()
 });
 
 agent.on("text",  async (ctx: any) => {
@@ -26,3 +27,15 @@ agent.on("start", (): void => {
 });
 
 await agent.start();
+
+
+
+export function getDbPath(description: string = "xmtp"): string {
+  // Checks if the environment is a Railway deployment
+  const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
+  // Create database directory if it doesn't exist
+  if (!fs.existsSync(volumePath)) {
+    fs.mkdirSync(volumePath, { recursive: true });
+  }
+  return `${volumePath}/${process.env.XMTP_ENV}-${description}.db3`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const agent = await Agent.createFromEnv({
   appVersion:'gm-bot/1.0.0',
   env: process.env.XMTP_ENV as "local" | "dev" | "production",
   loggingLevel: "warn" as LogLevel,
-  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot-` + process.env.XMTP_ENV
+  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot-` + process.env.XMTP_ENV+".db3"
 });
 
 agent.on("text",  async (ctx: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const agent = await Agent.createFromEnv({
   appVersion:'gm-bot/1.0.0',
   env: process.env.XMTP_ENV as "local" | "dev" | "production",
   loggingLevel: "warn" as LogLevel,
-  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot-` + process.env.XMTP_ENV+".db3"
+  dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot.db3`
 });
 
 agent.on("text",  async (ctx: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 
-import { Agent, getTestUrl, LogLevel,   } from "@xmtp/agent-sdk";
+import { Agent, getTestUrl, LogLevel, XmtpEnv  } from "@xmtp/agent-sdk";
 
 // Load .env file only in local development
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
@@ -8,7 +8,7 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
   // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
   appVersion:'gm-bot/1.0.0',
-  env: process.env.XMTP_ENV as "local" | "dev" | "production",
+  env: process.env.XMTP_ENV as XmtpEnv  ,
   loggingLevel: "warn" as LogLevel,
   dbPath: process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp/"+process.env.XMTP_ENV+ `-gm-bot.db3`
 });


### PR DESCRIPTION
### Add explicit process termination to `scripts/revokeInstallations.ts` and compute agent database path via `getDbPath` in `src/index.ts` to set `.db3` file under `RAILWAY_VOLUME_MOUNT_PATH` or `.data/xmtp`
- Add `process.exit(0)` at the end of the success path in the `main` function of [scripts/revokeInstallations.ts](https://github.com/xmtp/gm-bot/pull/66/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c).
- Import `XmtpEnv` and `fs` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/66/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), type the `env` option as `XmtpEnv`, and set `dbPath` via a new `getDbPath()` utility.
- Implement `getDbPath()` to build `${RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp"}/${XMTP_ENV}-${description}.db3`, ensure the directory exists, and default `description` to `"xmtp"`.

#### 📍Where to Start
Start with the `getDbPath` implementation and its usage in `Agent.createFromEnv` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/66/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), then review the `main` function changes in [scripts/revokeInstallations.ts](https://github.com/xmtp/gm-bot/pull/66/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c).

----

_[Macroscope](https://app.macroscope.com) summarized 8a32ebc._