### PR TITLE
Remove console log output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ const agent = await Agent.createFromEnv({
 });
 
 agent.on("text",  async (ctx: any) => {
-  console.log(ctx.message);
   await ctx.conversation.send("gm: " + ctx.message.content);
 });
 


### PR DESCRIPTION
### Remove console logging of `ctx.message` in the `agent.on('text', ...)` handler in [index.ts](https://github.com/xmtp/gm-bot/pull/67/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
Remove a `console.log` that outputs `ctx.message` inside the `agent.on('text', ...)` event handler in [index.ts](https://github.com/xmtp/gm-bot/pull/67/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), leaving only the conversation send call.

#### 📍Where to Start
Start with the `agent.on('text', ...)` handler in [index.ts](https://github.com/xmtp/gm-bot/pull/67/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized b434cd8._