### PR TITLE
Remove logging level config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,7 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
   // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
   appVersion:'gm-bot/1.0.0',
-  env: process.env.XMTP_ENV as XmtpEnv  ,
-  loggingLevel: "warn" as LogLevel,
+  env: process.env.XMTP_ENV as XmtpEnv,
   dbPath: getDbPath()
 });
 


### PR DESCRIPTION
### Remove explicit `loggingLevel: "warn"` configuration from `Agent.createFromEnv` invocation in [index.ts](https://github.com/xmtp/gm-bot/pull/68/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
This change removes the `loggingLevel: "warn"` option from the `Agent.createFromEnv` call in [index.ts](https://github.com/xmtp/gm-bot/pull/68/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) and normalizes spacing around the `env` option.

#### 📍Where to Start
Start with the `Agent.createFromEnv` invocation in [index.ts](https://github.com/xmtp/gm-bot/pull/68/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized e5acc74._