### PR TITLE
Remove hardcoded app version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
   // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
-  appVersion:'gm-bot/1.0.0',
   env: process.env.XMTP_ENV as XmtpEnv,
   dbPath: getDbPath()
 });


### PR DESCRIPTION
### Remove the hardcoded `appVersion: 'gm-bot/1.0.0'` from the `Agent.createFromEnv` call in [src/index.ts](https://github.com/xmtp/gm-bot/pull/69/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to align with the purpose of removing hardcoded app version
This change updates the call to `Agent.createFromEnv` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/69/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) by removing the `appVersion: 'gm-bot/1.0.0'` property from the options object, leaving only `env` and `dbPath`.

#### 📍Where to Start
Start with the `Agent.createFromEnv` invocation in [src/index.ts](https://github.com/xmtp/gm-bot/pull/69/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 5cddb5d._