### PR TITLE
Update agent-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gen:keys": "tsx scripts/generateKeys.ts"
   },
   "dependencies": {
-    "@xmtp/agent-sdk": "latest"
+    "@xmtp/agent-sdk": "^0.0.14"
   },
   "devDependencies": {
     "tsx": "^4.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,18 +253,18 @@
   dependencies:
     undici-types "~7.8.0"
 
-"@xmtp/agent-sdk@latest":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.12.tgz#da4dfd9fe93d926892e69eb09d9421bf28789bab"
-  integrity sha512-MgQeil6+21vMVGvFPksyoTXxf37EcoFOX/2rbquraQ7MDFqf+YKfODQVykuuOYQngKI9iUk0S/D299gTCvKrbA==
+"@xmtp/agent-sdk@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.14.tgz#c900e8e23987e4e0945cf4a7c8f69960f11b177f"
+  integrity sha512-oQ1BqmNnWpIYh0fZq7z0/hcBDx3GUSsimqR3enXq4XuXJxgf3SRP7ZTcfqtz6Wzx4gGpTYlQ4cdmBdser+m5gA==
   dependencies:
     "@xmtp/content-type-reaction" "^2.0.2"
     "@xmtp/content-type-remote-attachment" "^2.0.2"
     "@xmtp/content-type-reply" "^2.0.2"
     "@xmtp/content-type-text" "^2.0.2"
-    "@xmtp/node-sdk" "^4.1.0"
+    "@xmtp/node-sdk" "^4.1.1"
     uint8arrays "^5.1.0"
-    viem "^2.31.7"
+    viem "^2.37.6"
 
 "@xmtp/content-type-group-updated@^2.0.2":
   version "2.0.2"
@@ -317,10 +317,10 @@
   resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.4.0.tgz#aee7da306cf5edf2dbd5bbb81b5a9d1f121e2e75"
   integrity sha512-NfpbDc0gdhDY+5x1gxlv3I/5EtGLuwfkQszy08HXQHCchFrdpyA3NcnM9C2OQK7992H7f+bGEUlzaRze6Iqrbw==
 
-"@xmtp/node-sdk@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.1.0.tgz#5a4c987255e973d448820dcba3c99b590ef49485"
-  integrity sha512-tDXrwVnxUzyrjlmFE9FuBpR2j8OtE4hrDMLdBpEvoTjMHvWiPyzaxHoE8FZLOaSoW/zwncGHLH0VE59j7PQx+g==
+"@xmtp/node-sdk@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.1.1.tgz#70b1dc5c4af35bbc5f90a77f9c0580adf85bbef0"
+  integrity sha512-V6hcP5n1Tlrm0kHnHeJf8njLeiVLdl3sCBaiahq5E/cY9Y2yagZqOwO1cFbNNGddm30rbCUzExtJ7Cb+mfyesA==
   dependencies:
     "@xmtp/content-type-group-updated" "^2.0.2"
     "@xmtp/content-type-primitives" "^2.0.2"
@@ -489,10 +489,10 @@ undici@^5.8.1:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-viem@^2.31.7:
-  version "2.37.5"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.37.5.tgz#3df9e75bc25eabcf09db6d4b4a423a1f53413a37"
-  integrity sha512-bLKvKgLcge6KWBMLk8iP9weu5tHNr0hkxPNwQd+YQrHEgek7ogTBBeE10T0V6blwBMYmeZFZHLnMhDmPjp63/A==
+viem@^2.37.6:
+  version "2.37.6"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.37.6.tgz#3b05586555bd4b2c1b7351ed148f9fa98df72027"
+  integrity sha512-b+1IozQ8TciVQNdQUkOH5xtFR0z7ZxR8pyloENi/a+RA408lv4LoX12ofwoiT3ip0VRhO5ni1em//X0jn/eW0g==
   dependencies:
     "@noble/curves" "1.9.1"
     "@noble/hashes" "1.8.0"


### PR DESCRIPTION
### Pin web app dependency resolution to @xmtp/agent-sdk ^0.0.14 in file:package.json
- Update the dependency spec for `@xmtp/agent-sdk` to the semver range `^0.0.14` in [package.json](https://github.com/xmtp/gm-bot/pull/70/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
- Regenerate [yarn.lock](https://github.com/xmtp/gm-bot/pull/70/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect the updated dependency constraint

#### 📍Where to Start
Start with the dependency change in [package.json](https://github.com/xmtp/gm-bot/pull/70/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), then verify the resolved versions in [yarn.lock](https://github.com/xmtp/gm-bot/pull/70/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

----

_[Macroscope](https://app.macroscope.com) summarized 83dccf9._