### PR TITLE
Refactor dbPath function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
   // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
   env: process.env.XMTP_ENV as XmtpEnv,
-  dbPath: getDbPath()
+  dbPath: (inboxId) =>
+    process.env.RAILWAY_VOLUME_MOUNT_PATH ??
+    "." + `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
 agent.on("text",  async (ctx: any) => {
@@ -26,13 +28,3 @@ agent.on("start", (): void => {
 await agent.start();
 
 
-
-export function getDbPath(description: string = "xmtp"): string {
-  // Checks if the environment is a Railway deployment
-  const volumePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".data/xmtp";
-  // Create database directory if it doesn't exist
-  if (!fs.existsSync(volumePath)) {
-    fs.mkdirSync(volumePath, { recursive: true });
-  }
-  return `${volumePath}/${process.env.XMTP_ENV}-${description}.db3`;
-}


### PR DESCRIPTION
### Refactor `Agent.createFromEnv` db path handling in [src/index.ts](https://github.com/xmtp/gm-bot/pull/71/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to compute per-`inboxId` filenames for module bootstrapping
- Replace the `dbPath` option at the `Agent.createFromEnv` call site in [src/index.ts](https://github.com/xmtp/gm-bot/pull/71/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) with a callback that returns `process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "." + `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3``.
- Remove the exported `getDbPath` utility that previously selected/created a base directory and constructed an `XMTP_ENV`-scoped filename.

#### 📍Where to Start
Start at the `Agent.createFromEnv` call in [src/index.ts](https://github.com/xmtp/gm-bot/pull/71/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to review the new `dbPath` callback and its usage.

----

_[Macroscope](https://app.macroscope.com) summarized 1f6cabe._