### PR TITLE
Refactor logging in agent start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 
-import { Agent, getTestUrl, LogLevel, XmtpEnv  } from "@xmtp/agent-sdk";
-import fs from "fs";
+import { Agent, getTestUrl, logDetails  } from "@xmtp/agent-sdk";
 
 // Load .env file only in local development
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
@@ -8,7 +7,6 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
   // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
-  env: process.env.XMTP_ENV as XmtpEnv,
   dbPath: (inboxId) =>
     process.env.RAILWAY_VOLUME_MOUNT_PATH ??
     "." + `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
@@ -20,9 +18,7 @@ agent.on("text",  async (ctx: any) => {
 
 // 4. Log when we're ready
 agent.on("start", (): void => {
-  console.log(`Waiting for messages...`);
-  console.log(`Address: ${agent.client.accountIdentifier?.identifier}`);
-  console.log(`🔗${getTestUrl(agent)}`);
+  logDetails(agent.client)
 });
 
 await agent.start();


### PR DESCRIPTION
### Refactor agent startup logging by replacing manual console output with `logDetails` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/73/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Remove unused imports (`LogLevel`, `XmtpEnv`, `fs`) and add `logDetails` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/73/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Call `Agent.createFromEnv` without an explicit `env` option in [src/index.ts](https://github.com/xmtp/gm-bot/pull/73/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Replace three `console.log` calls in the agent `start` event handler with a single `logDetails(agent.client)` invocation in [src/index.ts](https://github.com/xmtp/gm-bot/pull/73/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)

#### 📍Where to Start
Start with the agent initialization and `start` event handler in [src/index.ts](https://github.com/xmtp/gm-bot/pull/73/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized a53f323._