### PR TITLE
Add logging to dbPath setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,13 @@ import { Agent, getTestUrl, logDetails  } from "@xmtp/agent-sdk";
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
 
-  // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
-  dbPath: (inboxId) =>
-    process.env.RAILWAY_VOLUME_MOUNT_PATH ??
-    "." + `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
+  dbPath: (inboxId) =>{
+    const path=process.env.RAILWAY_VOLUME_MOUNT_PATH ??
+    "." + `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`
+    console.log(path)
+    return path
+  }
 });
 
 agent.on("text",  async (ctx: any) => {


### PR DESCRIPTION
### Add console logging of resolved database path in `Agent.createFromEnv` dbPath callback to support dbPath setup
Replace the concise arrow expression in the `Agent.createFromEnv` `dbPath` callback with a block that computes the path, logs it to stdout using `console.log(path)`, and returns it in [index.ts](https://github.com/xmtp/gm-bot/pull/74/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

#### 📍Where to Start
Start with the `Agent.createFromEnv` `dbPath` callback in [index.ts](https://github.com/xmtp/gm-bot/pull/74/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 5bfd90e._