### PR TITLE
Refactor dbPath generation code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,7 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
 const agent = await Agent.createFromEnv({
   dbPath: (inboxId) =>{
-    const path=process.env.RAILWAY_VOLUME_MOUNT_PATH ??
-    "." + `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`
+    const path=(process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "." )+ `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`
     console.log(path)
     return path
   }


### PR DESCRIPTION
### Refactor dbPath generation in `Agent.createFromEnv` to always append `/${XMTP_ENV}-${inboxId.slice(0, 8)}.db3` after resolving the base path via nullish coalescing
Update the `options.dbPath` callback in `Agent.createFromEnv` to construct the file path by resolving the base path with nullish coalescing and then concatenating the suffix `/${XMTP_ENV}-${inboxId.slice(0, 8)}.db3`, ensuring the filename is appended whether `RAILWAY_VOLUME_MOUNT_PATH` is set or not. See [src/index.ts](https://github.com/xmtp/gm-bot/pull/75/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

#### 📍Where to Start
Start with the `Agent.createFromEnv` `options.dbPath` callback in [src/index.ts](https://github.com/xmtp/gm-bot/pull/75/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 2e91ef8._