### PR TITLE
Refactor dbPath function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,7 @@ if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");
 
 
 const agent = await Agent.createFromEnv({
-  dbPath: (inboxId) =>{
-    const path=(process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "." )+ `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`
-    console.log(path)
-    return path
-  }
+  dbPath: (inboxId) =>(process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "." )+ `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
 agent.on("text",  async (ctx: any) => {


### PR DESCRIPTION
### Refactor `Agent.createFromEnv` dbPath option to remove stdout logging in [index.ts](https://github.com/xmtp/gm-bot/pull/76/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
Convert the `Agent.createFromEnv` `dbPath` option to a concise expression-bodied arrow function and remove the console logging of the computed path in [index.ts](https://github.com/xmtp/gm-bot/pull/76/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

#### 📍Where to Start
Start with the `Agent.createFromEnv` configuration for `dbPath` in [index.ts](https://github.com/xmtp/gm-bot/pull/76/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 03f636f._