### PR TITLE
"Update agent-sdk version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gen:keys": "tsx scripts/generateKeys.ts"
   },
   "dependencies": {
-    "@xmtp/agent-sdk": "^0.0.15"
+    "@xmtp/agent-sdk": "^1.0.1"
   },
   "devDependencies": {
     "tsx": "^4.19.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   },
   "engines": {
     "node": ">=20"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,24 @@ const agent = await Agent.createFromEnv({
   dbPath: (inboxId) =>(process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "." )+ `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
-agent.on("text",  async (ctx: any) => {
-  await ctx.sendText("gm: " + ctx.message.content);
+
+agent.on("text", async (ctx) => {
+  if (ctx.isDm()) {
+    const messageContent = ctx.message.content;
+    const senderAddress = await ctx.getSenderAddress();
+    console.log(`Received message: ${messageContent} by ${senderAddress}`);
+    await ctx.sendText("gm");
+  }
+});
+
+agent.on("text", async (ctx) => {
+  if (ctx.isGroup() && ctx.message.content.includes("@gm")) {
+    const senderAddress = await ctx.getSenderAddress();
+    console.log(
+      `Received message in group: ${ctx.message.content} by ${senderAddress}`,
+    );
+    await ctx.sendText("gm");
+  }
 });
 
 // 4. Log when we're ready

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Agent,   } from "@xmtp/agent-sdk";
+import { Agent,  } from "@xmtp/agent-sdk";
 import { logDetails,  getTestUrl } from "@xmtp/agent-sdk/debug";
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
+import { Agent,   } from "@xmtp/agent-sdk";
+import { logDetails,  getTestUrl } from "@xmtp/agent-sdk/debug";
 
-import { Agent, getTestUrl, logDetails  } from "@xmtp/agent-sdk";
 
 // Load .env file only in local development
 if (process.env.NODE_ENV !== 'production') process.loadEnvFile(".env");

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,10 +253,10 @@
   dependencies:
     undici-types "~7.8.0"
 
-"@xmtp/agent-sdk@^0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-0.0.15.tgz#4ef1403c6192a7be7ea1b94fa0ad15459e22497b"
-  integrity sha512-4fNjnbycU++enTwY44u30nSLPsLe2XtdnJtA0Jih9BEH/pfw4STOhHV7SIhCvdQ1wdf6YSw1Ur5Fr8O/OzldDg==
+"@xmtp/agent-sdk@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-1.0.1.tgz#700fb6377c2a635c4a32525b178f5aa4af2a3711"
+  integrity sha512-edjoj2SAD100V8IMdfk0SM5egkT1HELBtUSVj7IZCsYa4q0VNXzk6ovuLHYn9RpVeuq6zYTXmxomVnBOa7B6xg==
   dependencies:
     "@xmtp/content-type-reaction" "^2.0.2"
     "@xmtp/content-type-remote-attachment" "^2.0.2"


### PR DESCRIPTION
### Update direct and group text handling to use @xmtp/agent-sdk v1.0.1 and reply with "gm" in DMs and on "@gm" in groups in [src/index.ts](https://github.com/xmtp/gm-bot/pull/78/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
This change upgrades `@xmtp/agent-sdk` to `^1.0.1`, updates imports to use `@xmtp/agent-sdk` and `@xmtp/agent-sdk/debug`, and modifies text handlers for direct and group conversations in [src/index.ts](https://github.com/xmtp/gm-bot/pull/78/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

- Update DM text handler to log sender and content and reply with `"gm"` only in direct messages in [src/index.ts](https://github.com/xmtp/gm-bot/pull/78/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Add group text handler that logs sender and content and replies with `"gm"` when the message includes `"@gm"` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/78/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Change imports to `Agent` from `@xmtp/agent-sdk` and `getTestUrl`/`logDetails` from `@xmtp/agent-sdk/debug` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/78/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)
- Bump dependency `@xmtp/agent-sdk` from `^0.0.15` to `^1.0.1` in [package.json](https://github.com/xmtp/gm-bot/pull/78/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and update [yarn.lock](https://github.com/xmtp/gm-bot/pull/78/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)

#### 📍Where to Start
Start with the text event handlers in `agent.on('text')` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/78/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----

_[Macroscope](https://app.macroscope.com) summarized 7275432._