### PR TITLE
Update agent-sdk, add events

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gen:keys": "tsx scripts/generateKeys.ts"
   },
   "dependencies": {
-    "@xmtp/agent-sdk": "^1.0.1"
+    "@xmtp/agent-sdk": "^1.1.0"
   },
   "devDependencies": {
     "tsx": "^4.19.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,15 @@ agent.on("text", async (ctx) => {
   }
 });
 
+
+agent.on("group", async (ctx) => {
+  console.log(`Received message in group: ${ctx.conversation.id}`);
+});
+
+agent.on("dm", async (ctx) => {
+  console.log(`Received message in group: ${ctx.conversation.id}`);
+});
+
 // 4. Log when we're ready
 agent.on("start", (): void => {
   logDetails(agent.client)

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,16 +253,16 @@
   dependencies:
     undici-types "~7.8.0"
 
-"@xmtp/agent-sdk@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-1.0.1.tgz#700fb6377c2a635c4a32525b178f5aa4af2a3711"
-  integrity sha512-edjoj2SAD100V8IMdfk0SM5egkT1HELBtUSVj7IZCsYa4q0VNXzk6ovuLHYn9RpVeuq6zYTXmxomVnBOa7B6xg==
+"@xmtp/agent-sdk@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@xmtp/agent-sdk/-/agent-sdk-1.1.0.tgz#4929ca0aca57e938535c4fc772031e053325df61"
+  integrity sha512-RvI6u1Jgnvn1STfoMERl5V64SlpBzBbiZuIjYEBXTxwAG8lKtmgvMGgHqfLF+dGqlP3PbROfCYltPLh0cHV11w==
   dependencies:
     "@xmtp/content-type-reaction" "^2.0.2"
     "@xmtp/content-type-remote-attachment" "^2.0.2"
     "@xmtp/content-type-reply" "^2.0.2"
     "@xmtp/content-type-text" "^2.0.2"
-    "@xmtp/node-sdk" "^4.1.2"
+    "@xmtp/node-sdk" "^4.2.0"
     uint8arrays "^5.1.0"
     viem "^2.37.6"
 
@@ -312,20 +312,20 @@
   dependencies:
     "@xmtp/content-type-primitives" "^2.0.2"
 
-"@xmtp/node-bindings@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.4.0.tgz#aee7da306cf5edf2dbd5bbb81b5a9d1f121e2e75"
-  integrity sha512-NfpbDc0gdhDY+5x1gxlv3I/5EtGLuwfkQszy08HXQHCchFrdpyA3NcnM9C2OQK7992H7f+bGEUlzaRze6Iqrbw==
+"@xmtp/node-bindings@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.5.2.tgz#8b94e35e4bc28f7312ac686727b7761c12f8a0f0"
+  integrity sha512-7YsH4Z7KZaZpfuZ+/FpWFUPCNsOPTyKPgCODuzA5D913OdJEjzu2ueEqdf3muI6VIGux632dGSK0mJpZx3DNCw==
 
-"@xmtp/node-sdk@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.1.2.tgz#90550be9016bd0465a86b85d286a60acafb9e5ae"
-  integrity sha512-ydz8RoxFWxaXFGiGzatZ9xAO037nOT0K/isE3IKK7E+gMCmbCVhZBaV5Sy2luNk5ndTQs+LsDYu1SZGC632Ejg==
+"@xmtp/node-sdk@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.2.0.tgz#baea3ff62d99192bb1b90f830524855a30b38b07"
+  integrity sha512-/AIAkXMWJMV8zNvN02EllHf7pMyWcXQR5Xh7heHsipYFI8VY2nElp6w26swd5YTSKdDKolOW4HBUBshrbKFr5A==
   dependencies:
     "@xmtp/content-type-group-updated" "^2.0.2"
     "@xmtp/content-type-primitives" "^2.0.2"
     "@xmtp/content-type-text" "^2.0.2"
-    "@xmtp/node-bindings" "1.4.0"
+    "@xmtp/node-bindings" "1.5.2"
 
 "@xmtp/proto@^3.78.0":
   version "3.86.0"


### PR DESCRIPTION
### Update dependency @xmtp/agent-sdk to ^1.1.0 and add event handlers for "group" and "dm" events in file:src/index.ts
This change updates the SDK version and adds logging for new agent events.

- Update `@xmtp/agent-sdk` dependency in [package.json](https://github.com/xmtp/gm-bot/pull/80/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `^1.0.1` to `^1.1.0`
- Add `"group"` event handler in [src/index.ts](https://github.com/xmtp/gm-bot/pull/80/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) that logs the group conversation id
- Add `"dm"` event handler in [src/index.ts](https://github.com/xmtp/gm-bot/pull/80/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) that logs the direct message conversation id
- Update [yarn.lock](https://github.com/xmtp/gm-bot/pull/80/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect dependency changes

#### 📍Where to Start
Start with the event registration and logging logic in [src/index.ts](https://github.com/xmtp/gm-bot/pull/80/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), focusing on the `"group"` and `"dm"` event handlers.

----

_[Macroscope](https://app.macroscope.com) summarized 870f137._