### PR TITLE
Ignore data/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 # misc
 .DS_Store
 *.pem
+data/
 
 # debug
 yarn-debug.log*

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const agent = await Agent.createFromEnv({
   disableDeviceSync: true,
   dbPath: (inboxId) =>
     (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".") +
-    `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
+    `/data/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
  async function getMessageBody(ctx: MessageContext) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Ignore the data directory in .gitignore and write Agent.createFromEnv SQLite DB files to <base>/data/<XMTP_ENV>-<inboxIdPrefix>.db3 in src/index.ts
Add `data/` to `.gitignore` and update `Agent.createFromEnv` to resolve `dbPath` under a `data` subdirectory as `<RAILWAY_VOLUME_MOUNT_PATH or '.'>/data/<XMTP_ENV>-<inboxIdPrefix>.db3`. See [src/index.ts](https://github.com/xmtp/gm-bot/pull/95/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) and [.gitignore](https://github.com/xmtp/gm-bot/pull/95/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947).

#### 📍Where to Start
Start with the `Agent.createFromEnv` initialization and `dbPath` construction in [src/index.ts](https://github.com/xmtp/gm-bot/pull/95/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 122a479.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->