### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 # misc
 .DS_Store
 *.pem
+data/
 
 # debug
 yarn-debug.log*

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const agent = await Agent.createFromEnv({
   disableDeviceSync: true,
   dbPath: (inboxId) =>
     (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".") +
-    `/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
+    `/data/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
  async function getMessageBody(ctx: MessageContext) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,10 +343,10 @@
   dependencies:
     "@xmtp/content-type-primitives" "^2.0.2"
 
-"@xmtp/node-bindings@1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.6.2.tgz#b68021341a0a3637223d518d55015e6a5b746ddf"
-  integrity sha512-7u1p/VE9dNzT+g3ulb/wEwG4OtYHsZJRJvUbqNkb/8P0/kse0rcmxljDfSX7RhsnAikzGhZSULl2tAWfnbXg9A==
+"@xmtp/node-bindings@1.6.2", "@xmtp/node-bindings@1.6.4-rc2":
+  version "1.6.4-rc2"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.6.4-rc2.tgz#236102d954ea62d2e429156c34f2966b773ee784"
+  integrity sha512-s7OCj/qo9lF7eUjaBPUpL2fm8I9wOC/2n/MpHdTbT7cJ+HaSLw19mCZOWA5QMP7J210X3kiHHtP5GzBg34OIMw==
 
 "@xmtp/node-sdk@4.3.1", "@xmtp/node-sdk@4.5.0-rc3":
   version "4.5.0-rc3"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Route Agent database files to a 'data' subdirectory and update ignore rules for the 'data' directory in [src/index.ts](https://github.com/xmtp/gm-bot/pull/96/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) and [.gitignore](https://github.com/xmtp/gm-bot/pull/96/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947)
`Agent.createFromEnv` updates the `dbPath` callback to write to `/data/${XMTP_ENV}-${inboxId.slice(0, 8)}.db3`, and `.gitignore` adds `data/`; lockfile updates are included.

#### 📍Where to Start
Start with the `Agent.createFromEnv` `dbPath` callback change in [src/index.ts](https://github.com/xmtp/gm-bot/pull/96/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2e4c11a.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->