### PR TITLE
Update .env loading logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 import { Agent, MessageContext } from "@xmtp/agent-sdk";
 import { getTestUrl, logDetails } from "@xmtp/agent-sdk/debug";
 
-// Load .env file only in local development
-if (process.env.NODE_ENV !== "production") process.loadEnvFile(".env");
+// Load .env file only in local development (not on Railway)
+if (process.env.NODE_ENV !== "production" && !process.env.RAILWAY_VOLUME_MOUNT_PATH) {
+  try {
+    process.loadEnvFile(".env");
+  } catch {
+    // .env file is optional
+  }
+}
 
 const agent = await Agent.createFromEnv({
   disableDeviceSync: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ if (process.env.NODE_ENV !== "production" && !process.env.RAILWAY_VOLUME_MOUNT_P
 const agent = await Agent.createFromEnv({
   disableDeviceSync: true,
   dbPath: (inboxId) =>
-    (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".") +
-    `/data/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
+    (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "./data/") +
+    `${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
  async function getMessageBody(ctx: MessageContext) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update .env loading in `src/index.ts` and adjust `Agent.createFromEnv` `options.dbPath` to use `RAILWAY_VOLUME_MOUNT_PATH` without a hardcoded /data/ subdirectory
In [src/index.ts](https://github.com/xmtp/gm-bot/pull/98/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), skip `.env` loading when `RAILWAY_VOLUME_MOUNT_PATH` is set and wrap `process.loadEnvFile(".env")` in a try/catch that suppresses errors. Update `Agent.createFromEnv` `options.dbPath` to build the filename using `RAILWAY_VOLUME_MOUNT_PATH` directly or `./data/` when absent.

#### 📍Where to Start
Start in the module env-loading block and the `Agent.createFromEnv` `options.dbPath` calculation in [src/index.ts](https://github.com/xmtp/gm-bot/pull/98/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized ddb4476.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->