### PR TITLE
Update node-bindings version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=22"
   },
   "resolutions": {
-    "@xmtp/node-sdk": "4.5.0-rc3",
+    "@xmtp/node-sdk": "4.5.0",
     "@xmtp/node-bindings": "1.6.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "resolutions": {
     "@xmtp/node-sdk": "4.5.0-rc3",
-    "@xmtp/node-bindings": "1.6.4-rc2"
+    "@xmtp/node-bindings": "1.6.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const agent = await Agent.createFromEnv({
     const senderAddress = (await ctx.getSenderAddress()) as string;
     const dateString = ctx.message.sentAt.toISOString();
 
-    const messageBody = `replying to a message sent by ${senderAddress} on ${dateString} on converstion ${ctx.conversation.id}. Content: "${messageContent}"`;
+    const messageBody = `replying from MAC to a message sent by ${senderAddress} on ${dateString} on converstion ${ctx.conversation.id}. Content: "${messageContent}"`;
 
     console.log(messageBody);
     return messageBody;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 import { Agent, MessageContext } from "@xmtp/agent-sdk";
 import { getTestUrl, logDetails } from "@xmtp/agent-sdk/debug";
 
-// Load .env file only in local development
-if (process.env.NODE_ENV !== "production") process.loadEnvFile(".env");
+// Load .env file only in local development (not on Railway)
+if (process.env.NODE_ENV !== "production" && !process.env.RAILWAY_VOLUME_MOUNT_PATH) {
+  try {
+    process.loadEnvFile(".env");
+  } catch {
+    // .env file is optional
+  }
+}
 
 const agent = await Agent.createFromEnv({
   disableDeviceSync: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ if (process.env.NODE_ENV !== "production" && !process.env.RAILWAY_VOLUME_MOUNT_P
 const agent = await Agent.createFromEnv({
   disableDeviceSync: true,
   dbPath: (inboxId) =>
-    (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".") +
-    `/data/${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
+    (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "./data/") +
+    `${process.env.XMTP_ENV}-${inboxId.slice(0, 8)}.db3`,
 });
 
  async function getMessageBody(ctx: MessageContext) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,20 +343,20 @@
   dependencies:
     "@xmtp/content-type-primitives" "^2.0.2"
 
-"@xmtp/node-bindings@1.6.2", "@xmtp/node-bindings@1.6.6":
+"@xmtp/node-bindings@1.6.6":
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.6.6.tgz#7badfdc69f3db755a02e5d579c167c836a85e799"
   integrity sha512-NIN0LiXvkKKhXaHK2bSfWM/fC0BiRim9ryk+MifISoASy3JcFYeqpxnW5pceYxGdx1HJ2/Sz/luwEIplYCxlPw==
 
-"@xmtp/node-sdk@4.3.1", "@xmtp/node-sdk@4.5.0-rc3":
-  version "4.5.0-rc3"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.5.0-rc3.tgz#f7dd2142074f4ab101cedb4e2e37ef3a84429c8b"
-  integrity sha512-2uqPVm64PME7G2AI5c/LW5Bu128n9/qT6XrDfcgS30Tjrohb8dSQSedS8t7BlWFZ5LdfqmZZdssNfOQ2vUReqA==
+"@xmtp/node-sdk@4.3.1", "@xmtp/node-sdk@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-sdk/-/node-sdk-4.5.0.tgz#46f145914f9962a9ccffa406f48cbc4b3fbdf725"
+  integrity sha512-jFfVEhBZMjttuhzkVECLHlQKy1iFV6/hGwRQJt4yZuHwlJlhz4sr0NpI/UoLdYBKgky8MXKjKjww+ivZeAV2WQ==
   dependencies:
     "@xmtp/content-type-group-updated" "^2.0.2"
     "@xmtp/content-type-primitives" "^2.0.2"
     "@xmtp/content-type-text" "^2.0.2"
-    "@xmtp/node-bindings" "1.6.2"
+    "@xmtp/node-bindings" "1.6.6"
 
 "@xmtp/proto@^3.78.0":
   version "3.87.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,10 +343,10 @@
   dependencies:
     "@xmtp/content-type-primitives" "^2.0.2"
 
-"@xmtp/node-bindings@1.6.2", "@xmtp/node-bindings@1.6.4-rc2":
-  version "1.6.4-rc2"
-  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.6.4-rc2.tgz#236102d954ea62d2e429156c34f2966b773ee784"
-  integrity sha512-s7OCj/qo9lF7eUjaBPUpL2fm8I9wOC/2n/MpHdTbT7cJ+HaSLw19mCZOWA5QMP7J210X3kiHHtP5GzBg34OIMw==
+"@xmtp/node-bindings@1.6.2", "@xmtp/node-bindings@1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@xmtp/node-bindings/-/node-bindings-1.6.6.tgz#7badfdc69f3db755a02e5d579c167c836a85e799"
+  integrity sha512-NIN0LiXvkKKhXaHK2bSfWM/fC0BiRim9ryk+MifISoASy3JcFYeqpxnW5pceYxGdx1HJ2/Sz/luwEIplYCxlPw==
 
 "@xmtp/node-sdk@4.3.1", "@xmtp/node-sdk@4.5.0-rc3":
   version "4.5.0-rc3"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update @xmtp/node-bindings and adjust database path handling in `Agent.createFromEnv` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/99/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) to align with the dependency bump motivation
Bumps `@xmtp/node-sdk` to `4.5.0` and `@xmtp/node-bindings` to `1.6.6`, adjusts `.env` loading to skip when `RAILWAY_VOLUME_MOUNT_PATH` is set and to ignore load failures, updates `Agent.createFromEnv` database path construction to use `RAILWAY_VOLUME_MOUNT_PATH` directly or default to `./data/`, and changes `getMessageBody` to include "replying from MAC". See [package.json](https://github.com/xmtp/gm-bot/pull/99/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [src/index.ts](https://github.com/xmtp/gm-bot/pull/99/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), and lockfile updates.

#### 📍Where to Start
Start with `Agent.createFromEnv` in [src/index.ts](https://github.com/xmtp/gm-bot/pull/99/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80), then review the top-level `.env` loading block and the `getMessageBody` helper in the same file.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 47b5f48.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->