### PR TITLE
Add debug and keygen scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "build": "tsc",
     "start": "tsx src/index.ts",
-    "dev": "tsx --watch src/index.ts"
+    "dev": "tsx --watch src/index.ts",
+    "debug-dm": "tsx scripts/debug-dm.ts",
+    "gen:keys": "npx @xmtp/cli keys "
   },
   "dependencies": {
     "@xmtp/agent-sdk": "1.1.16"

--- a/scripts/debug-dm.ts
+++ b/scripts/debug-dm.ts
@@ -1,0 +1,104 @@
+import { Agent } from "@xmtp/agent-sdk";
+
+process.loadEnvFile(".env");
+
+const MESSAGE = "PING";
+const TIMEOUT_SECONDS = 10;
+const STREAM_SETUP_DELAY_MS = 500;
+
+async function waitForResponse(
+  agent: Agent,
+  conversation: any,
+  conversationId: string,
+  message: string,
+) {
+  const stream = await agent.client.conversations.streamAllMessages();
+  const startTime = performance.now();
+  let timeoutId: NodeJS.Timeout | null = null;
+  let done = false;
+
+  const responsePromise = (async () => {
+    try {
+      for await (const msg of stream) {
+        if (done) break;
+        if (
+          msg.conversationId !== conversationId ||
+          msg.senderInboxId.toLowerCase() === agent.client.inboxId.toLowerCase()
+        ) {
+          continue;
+        }
+        done = true;
+        return msg;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  })();
+
+  await new Promise((resolve) => setTimeout(resolve, STREAM_SETUP_DELAY_MS));
+
+  await conversation.send(message);
+  const sendTime = performance.now() - startTime;
+
+  try {
+    const timeoutPromise = new Promise<null>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("Timeout")),
+        TIMEOUT_SECONDS * 1000,
+      );
+    });
+
+    const response = await Promise.race([responsePromise, timeoutPromise]);
+    const responseTime = performance.now() - startTime;
+
+    return {
+      sendTime,
+      responseTime,
+      responseMessage: response,
+    };
+  } catch {
+    done = true;
+    return {
+      sendTime,
+      responseTime: performance.now() - startTime,
+      responseMessage: null,
+    };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    done = true;
+  }
+}
+
+async function main() {
+  const target = process.argv[2];
+  if (!target) {
+    console.error("Error: Target address required");
+    process.exit(1);
+  }
+
+  const agent = await Agent.createFromEnv({});
+  try {
+    const dm = await agent.createDmWithAddress(target as `0x${string}`);
+    const result = await waitForResponse(agent, dm, dm.id, MESSAGE);
+
+    console.log(`✅ Message sent (${result.sendTime.toFixed(2)}ms)`);
+    if (result.responseMessage) {
+      const content =
+        typeof result.responseMessage.content === "string"
+          ? result.responseMessage.content
+          : JSON.stringify(result.responseMessage.content);
+      console.log(`📬 Response (${result.responseTime.toFixed(2)}ms): "${content}"`);
+    } else {
+      console.log(`❌ No response within ${TIMEOUT_SECONDS}s`);
+    }
+  } finally {
+    await agent.stop();
+    process.exit(0);
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error("Error:", error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add npm scripts for DM debugging and key generation and introduce `scripts/debug-dm.ts` CLI that sends 'PING' and waits up to 10 seconds with a 500 ms stream setup delay
Add `debug-dm` and `gen:keys` npm scripts in [package.json](https://github.com/xmtp/gm-bot/pull/101/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and implement a CLI in [scripts/debug-dm.ts](https://github.com/xmtp/gm-bot/pull/101/files#diff-4b8ee11a8b20a20432f8cf57e56ccdcea977c64d20d04515fa825d242dc0c52d) that creates a DM via `@xmtp/agent-sdk`, sends `PING`, streams replies, and times out after 10 seconds.

#### 📍Where to Start
Start with `main()` in [scripts/debug-dm.ts](https://github.com/xmtp/gm-bot/pull/101/files#diff-4b8ee11a8b20a20432f8cf57e56ccdcea977c64d20d04515fa825d242dc0c52d), then review `waitForResponse()` for the streaming and timeout logic.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fc74792. 1 file reviewed, 5 issues evaluated, 2 issues filtered, 2 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>scripts/debug-dm.ts — 2 comments posted, 5 evaluated, 2 filtered</summary>

- [line 3](https://github.com/xmtp/gm-bot/blob/fc74792b78761d9e8d2da76a18333e485680f1f5/scripts/debug-dm.ts#L3): `process.loadEnvFile` is invoked at module load, but this API is only available on newer Node.js versions. On runtimes where it is absent, this will throw `TypeError: process.loadEnvFile is not a function` at startup, aborting the script before any guards or cleanup can run. <b>[ Low confidence ]</b>
- [line 15](https://github.com/xmtp/gm-bot/blob/fc74792b78761d9e8d2da76a18333e485680f1f5/scripts/debug-dm.ts#L15): `waitForResponse` never cancels/closes the message stream obtained from `agent.client.conversations.streamAllMessages()` on any exit path (success, timeout, or error). The `done` flag only breaks the loop when another message arrives; if no further messages arrive after a timeout, the `for await` loop and underlying stream remain active indefinitely, leaking resources and background work after the function returns. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->